### PR TITLE
Fixing lm4f120 timer handling for wtimer0/1

### DIFF
--- a/boards/ek-lm4f120xl/include/periph_conf.h
+++ b/boards/ek-lm4f120xl/include/periph_conf.h
@@ -42,7 +42,7 @@ extern "C" {
  */
 #define TIMER_NUMOF         (2U)
 #define TIMER_0_EN          1
-#define TIMER_1_EN          0
+#define TIMER_1_EN          1
 #define TIMER_IRQ_PRIO      1
 
 /* Timer 0 configuration */
@@ -50,6 +50,7 @@ extern "C" {
 #define TIMER_0_PRESCALER   (39U)
 #define TIMER_0_MAX_VALUE   (0xffffffff)
 #define TIMER_0_ISR         isr_wtimer0a
+#define TIMER_0_ICR         WTIMER0_ICR_R
 #define TIMER_0_IRQ_CHAN    Timer0A_IRQn
 
 /* Timer 1 configuration */
@@ -57,6 +58,7 @@ extern "C" {
 #define TIMER_1_PRESCALER   (39U)
 #define TIMER_1_MAX_VALUE   (0xffffffff)
 #define TIMER_1_ISR         isr_wtimer1a
+#define TIMER_1_ICR         WTIMER1_ICR_R
 #define TIMER_1_IRQ_CHAN    Timer1A_IRQn
 /** @} */
 
@@ -64,9 +66,9 @@ extern "C" {
  * @name UART configuration
  * @{
  */
-#define UART_NUMOF          (1U)
+#define UART_NUMOF          (2U)
 #define UART_0_EN           1
-#define UART_1_EN           0
+#define UART_1_EN           1
 #define UART_IRQ_PRIO       1
 #define UART_CLK            ROM_SysCtlClockGet()  /* UART clock runs with 40MHz */
 /* UART 0 device configuration */
@@ -74,16 +76,23 @@ extern "C" {
 #define UART_0_CLK          (40000000)
 #define UART_0_IRQ_CHAN     UART0_IRQn
 #define UART_0_ISR          isr_uart0
+#define UART_0_IM           UART0_IM_R
 /* UART 0 pin configuration */
-#define UART_0_PORT         GPIOA
-#define UART_0_TX_PIN       UART_PA1_U0TX
-#define UART_0_RX_PIN       UART_PA0_U0RX
+#define UART_0_PORT         SYSCTL_PERIPH_GPIOA
+#define UART_0_TX_PIN       GPIO_PA1_U0TX
+#define UART_0_RX_PIN       GPIO_PA0_U0RX
 
 /* UART 1 device configuration */
 #define UART_1_DEV          UART1_BASE
 #define UART_1_CLK          (40000000)
 #define UART_1_IRQ_CHAN     UART1_IRQn
 #define UART_1_ISR          isr_uart1
+#define UART_1_IM           UART1_IM_R
+#
+/* UART 1 pin configuration */
+#define UART_1_PORT         SYSCTL_PERIPH_GPIOB
+#define UART_1_TX_PIN       GPIO_PB1_U1TX
+#define UART_1_RX_PIN       GPIO_PB0_U1RX
 /** @} */
 
 #ifdef __cplusplus

--- a/cpu/lm4f120/periph/timer.c
+++ b/cpu/lm4f120/periph/timer.c
@@ -27,8 +27,12 @@
 
 #define ENABLE_DEBUG (0)
 #include "debug.h"
-/* guard file in case no timers are defined */
-#if TIMER_0_EN
+
+/* guard the file in case no TIMER is defined */
+#if TIMER_NUMOF
+
+/** Unified IRQ handler for all timers */
+static inline void irq_handler(tim_t timer);
 
 /**
  * @brief Struct holding the configuration data
@@ -38,129 +42,279 @@ typedef struct {
     void (*cb)(int);            /**< timeout callback */
 } timer_conf_t;
 
+/** Timer state memory */
 static timer_conf_t config[TIMER_NUMOF];
 /**@}*/
 
+/**
+ * The list of Timer peripherals.
+ */
+static const unsigned long g_ulTimerPeriph[2] =
+{
+    SYSCTL_PERIPH_WTIMER0,
+    SYSCTL_PERIPH_WTIMER1
+};
+
+/**
+ * The list of all possible base address of the timer
+ */
+static const unsigned long g_ulTimerBase[2] =
+{
+    WTIMER0_BASE,
+    WTIMER1_BASE
+};
+
+/**
+ * The list of possible interrupts for the Timer.
+ */
+static const unsigned long g_ulTimerInt[2] =
+{
+    INT_WTIMER0A,
+    INT_WTIMER1A
+};
+
 int timer_init(tim_t dev, unsigned int us_per_tick, void (*callback)(int))
 {
-    if (dev == TIMER_0) {
-        config[dev].cb = callback;                          /* User Function */
-        ROM_SysCtlPeripheralEnable(SYSCTL_PERIPH_WTIMER0);  /* Activate Timer0 */
-        WTIMER0_CTL_R &= ~0x00000001;                       /* Disable timer0A during setup */
-        WTIMER0_CFG_R  = TIMER_CFG_16_BIT;
-        WTIMER0_TAMR_R = TIMER_TAMR_TAMR_PERIOD;            /* Configure for periodic mode */
-        WTIMER0_TAPR_R = TIMER_0_PRESCALER;                 /* 1us timer0A */
-        WTIMER0_ICR_R  = 0x00000001;                        /* clear timer0A timeout flag */
-        WTIMER0_IMR_R |= 0x00000001;                        /* arm timeout interrupt */
-        ROM_IntPrioritySet(INT_WTIMER0A, 32);
-        timer_irq_enable(dev);
-        timer_start(dev);
-        DEBUG("startTimeout Value=0x%lx\n", ROM_TimerValueGet(WTIMER0_BASE, TIMER_A));
-        return 1;
+    ROM_SysCtlPeripheralEnable(g_ulTimerPeriph[dev]);           /* Activate Timer */
+    switch (dev){
+#if TIMER_0_EN
+        case TIMER_0:
+            WTIMER0_CTL_R &= ~0x00000001;                       /* Disable timer0A during setup */
+            WTIMER0_CFG_R  = TIMER_CFG_16_BIT;
+            WTIMER0_TAMR_R = TIMER_TAMR_TAMR_PERIOD;            /* Configure for periodic mode */
+            WTIMER0_TAPR_R = TIMER_0_PRESCALER;                 /* 1us timer0A */
+            WTIMER0_ICR_R  = 0x00000001;                        /* clear timer0A timeout flag */
+            WTIMER0_IMR_R |= 0x00000001;                        /* arm timeout interrupt */
+            break;
+#endif
+#if TIMER_1_EN
+        case TIMER_1:
+            WTIMER1_CTL_R &= ~0x00000001;                       /* Disable timer1A during setup */
+            WTIMER1_CFG_R  = TIMER_CFG_16_BIT;
+            WTIMER1_TAMR_R = TIMER_TAMR_TAMR_PERIOD;            /* Configure for periodic mode */
+            WTIMER1_TAPR_R = TIMER_1_PRESCALER;                 /* 1us timer1A */
+            WTIMER1_ICR_R  = 0x00000001;                        /* clear timer1A timeout flag */
+            WTIMER1_IMR_R |= 0x00000001;                        /* arm timeout interrupt */
+            break;
+#endif
+        case TIMER_UNDEFINED:
+        default:
+            return -1;
     }
-    return -1;
+
+    /* set callback function */
+    config[dev].cb = callback;
+
+    /* set timer's IRQ priority */
+    ROM_IntPrioritySet(g_ulTimerInt[dev], 32);
+
+    /* enable the timer's interrupt */
+    timer_irq_enable(dev);
+
+    /* start the timer */
+    timer_start(dev);
+
+    DEBUG("startTimeout Value=0x%lx\n", ROM_TimerValueGet(g_ulTimerBase[dev], TIMER_A));
+
+    return 0;
 }
 
 int timer_set(tim_t dev, int channel, unsigned int timeout)
 {
-    if (dev == TIMER_0) {
-        unsigned int now = timer_read(dev);
-        DEBUG("timer_set now=0x%x\n",now);
-        DEBUG("timer_set timeout=0x%x\n", timeout);
-        return timer_set_absolute(dev, channel, now+timeout);
-    }
-    return -1;
+    unsigned int now = timer_read(dev);
+    DEBUG("timer_set now=0x%x\n",now);
+    DEBUG("timer_set timeout=0x%x\n", timeout);
+    return timer_set_absolute(dev, channel, now+timeout);
 }
 
 int timer_set_absolute(tim_t dev, int channel, unsigned int value)
 {
-    if (dev == TIMER_0) {
-        WTIMER0_TAILR_R = 0x00000000 | value;               /* period; Reload value */
-        DEBUG("Setting timer absolute value=0x%x\n", value);
-        return 1;
+    switch (dev){
+#if TIMER_0_EN
+        case TIMER_0:
+            WTIMER0_TAILR_R = 0x00000000 | value;               /* period; Reload value */
+            break;
+#endif
+#if TIMER_1_EN
+        case TIMER_1:
+            WTIMER1_TAILR_R = 0x00000000 | value;               /* period; Reload value */
+            break;
+#endif
+        case TIMER_UNDEFINED:
+        default:
+            return -1;
     }
-    return -1;
+
+    DEBUG("Setting timer absolute value=0x%x\n", value);
+    return 0;
 }
 
 int timer_clear(tim_t dev, int channel)
 {
-    if (dev == TIMER_0){
-        WTIMER0_ICR_R = TIMER_ICR_TATOCINT;
-        return 1;
+    switch (dev){
+#if TIMER_0_EN
+        case TIMER_0:
+            WTIMER0_ICR_R = TIMER_ICR_TATOCINT;
+            break;
+#endif
+#if TIMER_1_EN
+        case TIMER_1:
+            WTIMER1_ICR_R = TIMER_ICR_TATOCINT;
+            break;
+#endif
+        case TIMER_UNDEFINED:
+        default:
+            return -1;
     }
     return -1;
 }
 
 unsigned int timer_read(tim_t dev)
 {
-    if (dev == TIMER_0) {
-        unsigned int currTimer0Val=0;
-        unsigned int loadTimer0Val=0;
-        currTimer0Val = (unsigned int)ROM_TimerValueGet(WTIMER0_BASE, TIMER_A);
-        loadTimer0Val = (unsigned int)ROM_TimerLoadGet(WTIMER0_BASE, TIMER_A);
-        DEBUG("WTIMER0_TAILR_R=0x%lx\t currTimer0Val=0x%x\t loadTimer0Val=0x%x\n", WTIMER0_TAILR_R, currTimer0Val, loadTimer0Val);
-        return (loadTimer0Val - currTimer0Val);
+    unsigned int currTimerVal=0;
+    unsigned int loadTimerVal=0;
+    switch(dev){
+#if TIMER_0_EN
+        case TIMER_0:
+            currTimerVal = (unsigned int)ROM_TimerValueGet(g_ulTimerBase[dev], TIMER_A);
+            loadTimerVal = (unsigned int)ROM_TimerLoadGet(g_ulTimerBase[dev], TIMER_A);
+            break;
+#endif
+#if TIMER_1_EN
+        case TIMER_1:
+            currTimerVal = (unsigned int)ROM_TimerValueGet(g_ulTimerBase[dev], TIMER_A);
+            loadTimerVal = (unsigned int)ROM_TimerLoadGet(g_ulTimerBase[dev], TIMER_A);
+            break;
+#endif
+        case TIMER_UNDEFINED:
+        default:
+            return 0;
     }
-    return 0;
+    DEBUG("Timer Read currTimerVal=0x%x\t loadTimerVal=0x%x\n", currTimerVal, loadTimerVal);
+    return (loadTimerVal - currTimerVal);
 }
 
 void timer_start(tim_t dev)
 {
-    if (dev == TIMER_0) {
-        ROM_TimerEnable(WTIMER0_BASE, TIMER_A);
+    switch(dev){
+#if TIMER_0_EN
+        case TIMER_0:
+            ROM_TimerEnable(g_ulTimerBase[dev], TIMER_A);
+            break;
+#endif
+#if TIMER_1_EN
+        case TIMER_1:
+            ROM_TimerEnable(g_ulTimerBase[dev], TIMER_A);
+            break;
+#endif
+        case TIMER_UNDEFINED:
+        default:
+            break;
     }
 }
 
 void timer_stop(tim_t dev)
 {
-    if (dev == TIMER_0) {
-        ROM_TimerDisable(WTIMER0_BASE, TIMER_A);
+    switch (dev) {
+#if TIMER_0_EN
+        case TIMER_0:
+            ROM_TimerDisable(g_ulTimerBase[dev], TIMER_A);
+            break;
+#endif
+#if TIMER_1_EN
+        case TIMER_1:
+            ROM_TimerDisable(g_ulTimerBase[dev], TIMER_A);
+            break;
+#endif
+        case TIMER_UNDEFINED:
+        default:
+            break;
     }
 }
 
 void timer_irq_enable(tim_t dev)
 {
-    if (dev == TIMER_0) {
-        ROM_IntEnable(INT_WTIMER0A);
-        ROM_TimerIntEnable(WTIMER0_BASE, TIMER_TIMA_TIMEOUT);
+    switch (dev) {
+#if TIMER_0_EN
+        case TIMER_0 :
+            ROM_IntEnable(g_ulTimerInt[dev]);
+            ROM_TimerIntEnable(g_ulTimerBase[dev], TIMER_TIMA_TIMEOUT);
+            break;
+#endif
+#if TIMER_1_EN
+        case TIMER_1 :
+            ROM_IntEnable(g_ulTimerInt[dev]);
+            ROM_TimerIntEnable(g_ulTimerBase[dev], TIMER_TIMA_TIMEOUT);
+            break;
+#endif
+        case TIMER_UNDEFINED:
+        default:
+            break;
     }
 }
 
 void timer_irq_disable(tim_t dev)
 {
-    if (dev == TIMER_0) {
-        ROM_IntDisable(INT_WTIMER0A);
+    switch (dev) {
+#if TIMER_0_EN
+        case TIMER_0 :
+            ROM_IntDisable(g_ulTimerInt[dev]);
+            break;
+#endif
+#if TIMER_1_EN
+        case TIMER_1 :
+            ROM_IntDisable(g_ulTimerInt[dev]);
+            break;
+#endif
+        case TIMER_UNDEFINED:
+        default:
+            break;
     }
 }
 
 void timer_reset(tim_t dev)
 {
-    if (dev == TIMER_0) {
-        /* Performs a software reset of a peripheral */
-        ROM_SysCtlPeripheralReset(SYSCTL_PERIPH_WTIMER0);
+    switch (dev) {
+#if TIMER_0_EN
+        case TIMER_0 :
+            /* Performs a software reset of a peripheral */
+            ROM_SysCtlPeripheralReset(g_ulTimerPeriph[dev]);
+            break;
+#endif
+#if TIMER_1_EN
+        case TIMER_1 :
+            /* Performs a software reset of a peripheral */
+            ROM_SysCtlPeripheralReset(g_ulTimerPeriph[dev]);
+            break;
+#endif
+        case TIMER_UNDEFINED:
+        default:
+            break;
     }
 }
 
 #if TIMER_0_EN
-void isr_timer0a(void)
-{
-    TIMER0_ICR_R = TIMER_ICR_TATOCINT;
-    config[TIMER_0].cb(0);
-
-    if (sched_context_switch_request){
-        thread_yield();
-    }
-}
-void isr_wtimer0a(void)
+void TIMER_0_ISR(void)
 {
     WTIMER0_ICR_R = TIMER_ICR_TATOCINT;
+    irq_handler(TIMER_0);
+}
+#endif
 
-    config[TIMER_0].cb(0);
+#if TIMER_1_EN
+void TIMER_1_ISR(void)
+{
+    WTIMER1_ICR_R = TIMER_ICR_TATOCINT;
+    irq_handler(TIMER_1);
+}
+#endif
+
+static inline void irq_handler(tim_t timer)
+{
+    config[timer].cb(0);
     if (sched_context_switch_request){
         thread_yield();
     }
 }
-#endif /* TIMER_0_EN */
-
-#endif /* TIMER_0_EN */
+#endif /*TIMER_NUMOF */
 /** @} */

--- a/cpu/lm4f120/periph/uart.c
+++ b/cpu/lm4f120/periph/uart.c
@@ -26,7 +26,7 @@
 #include "periph_conf.h"
 
 /* guard the file in case no UART is defined */
-#if UART_0_EN
+#if UART_NUMOF
 
 /**
  * @brief Struct holding the configuration data for a UART device
@@ -40,6 +40,15 @@ typedef struct {
 /**@}*/
 
 /**
+ * @brief Unified interrupt handler for all UART devices
+ *
+ * @param uartnum       the number of the UART that triggered the ISR
+ * @param ulBase        the UART device that triggered the ISR
+ * @param ulRxInt       the RX Interrupt Mask of the UART Device that triggered the ISR
+ */
+static inline void irq_handler(uart_t uartnum, unsigned long ulBase, unsigned long ulRxInt);
+
+/**
  * @brief UART device configurations
  */
 static uart_conf_t config[UART_NUMOF];
@@ -47,31 +56,19 @@ static uart_conf_t config[UART_NUMOF];
 /**
  * The list of UART peripherals.
  */
-static const unsigned long g_ulUARTPeriph[3] =
+static unsigned long g_ulUARTPeriph[2] =
 {
     SYSCTL_PERIPH_UART0,
-    SYSCTL_PERIPH_UART1,
-    SYSCTL_PERIPH_UART2
+    SYSCTL_PERIPH_UART1
 };
 
 /**
  * The list of all possible base address of the console UART
  */
-static const unsigned long g_ulUARTBase[3] =
+static const unsigned long g_ulUARTBase[2] =
 {
     UART0_BASE,
-    UART1_BASE,
-    UART2_BASE
-};
-
-/**
- * The list of possible interrupts for the console UART.
- */
-static const unsigned long g_ulUARTInt[3] =
-{
-    INT_UART0,
-    INT_UART1,
-    INT_UART2
+    UART1_BASE
 };
 
 /**
@@ -80,9 +77,9 @@ static const unsigned long g_ulUARTInt[3] =
 int uart_init(uart_t uart, uint32_t baudrate, uart_rx_cb_t rx_cb, uart_tx_cb_t tx_cb, void *arg)
 {
     /* Check the arguments */
-    assert(uart == 0);
+    assert((uart == 0) || (uart == 1));
     /* Check to make sure the UART peripheral is present */
-    if(!ROM_SysCtlPeripheralPresent(SYSCTL_PERIPH_UART0)){
+    if(!ROM_SysCtlPeripheralPresent(g_ulUARTPeriph[uart])){
         return -1;
     }
 
@@ -91,32 +88,39 @@ int uart_init(uart_t uart, uint32_t baudrate, uart_rx_cb_t rx_cb, uart_tx_cb_t t
         return res;
     }
 
-/* save callbacks */
+    /* save callbacks */
     config[uart].rx_cb = rx_cb;
     config[uart].tx_cb = tx_cb;
     config[uart].arg = arg;
 
-/*  ulBase = g_ulUARTBase[uart]; */
+
     switch (uart){
 #if UART_0_EN
         case UART_0:
             NVIC_SetPriority(UART_0_IRQ_CHAN, UART_IRQ_PRIO);
 
-            ROM_UARTTxIntModeSet(UART0_BASE, UART_TXINT_MODE_EOT);
-            ROM_UARTFIFOLevelSet(UART0_BASE, UART_FIFO_TX4_8, UART_FIFO_RX4_8);
-            ROM_UARTFIFOEnable(UART0_BASE);
+            ROM_UARTTxIntModeSet(g_ulUARTBase[uart], UART_TXINT_MODE_EOT);
+            ROM_UARTFIFOLevelSet(g_ulUARTBase[uart], UART_FIFO_TX4_8, UART_FIFO_RX4_8);
+            ROM_UARTFIFOEnable(g_ulUARTBase[uart]);
 
             /* Enable the UART interrupt */
             NVIC_EnableIRQ(UART_0_IRQ_CHAN);
             /* Enable RX interrupt */
-            UART0_IM_R = UART_IM_RXIM | UART_IM_RTIM;
+            UART_0_IM = UART_IM_RXIM | UART_IM_RTIM;
             break;
 #endif
 #if UART_1_EN
         case UART_1:
             NVIC_SetPriority(UART_1_IRQ_CHAN, UART_IRQ_PRIO);
+
+            ROM_UARTTxIntModeSet(g_ulUARTBase[uart], UART_TXINT_MODE_EOT);
+            ROM_UARTFIFOLevelSet(g_ulUARTBase[uart], UART_FIFO_TX4_8, UART_FIFO_RX4_8);
+            ROM_UARTFIFOEnable(g_ulUARTBase[uart]);
+
             /* Enable the UART interrupt */
             NVIC_EnableIRQ(UART_1_IRQ_CHAN);
+            /* Enable RX interrupt */
+            UART_1_IM = UART_IM_RXIM | UART_IM_RTIM;
             break;
 #endif
     }
@@ -125,95 +129,185 @@ int uart_init(uart_t uart, uint32_t baudrate, uart_rx_cb_t rx_cb, uart_tx_cb_t t
 
 int uart_init_blocking(uart_t uart, uint32_t baudrate)
 {
+    /*The base address of the chosen UART */
+    unsigned long ulBase = g_ulUARTBase[uart];
+
+    ROM_SysCtlPeripheralEnable(g_ulUARTPeriph[uart]);
     switch(uart){
 #if UART_0_EN
         case UART_0:
-            ROM_SysCtlPeripheralEnable(SYSCTL_PERIPH_UART0);
-            ROM_SysCtlPeripheralEnable(SYSCTL_PERIPH_GPIOA);
-            ROM_GPIOPinConfigure(GPIO_PA0_U0RX);
-            ROM_GPIOPinConfigure(GPIO_PA1_U0TX);
+            ROM_SysCtlPeripheralEnable(UART_0_PORT);
+            ROM_GPIOPinConfigure(UART_0_RX_PIN);
+            ROM_GPIOPinConfigure(UART_0_TX_PIN);
             ROM_GPIOPinTypeUART(GPIO_PORTA_BASE, GPIO_PIN_0 | GPIO_PIN_1);
-
-            ROM_UARTDisable(UART0_BASE);
-            ROM_UARTConfigSetExpClk(UART0_BASE,ROM_SysCtlClockGet(), baudrate,
-                    (UART_CONFIG_PAR_NONE | UART_CONFIG_STOP_ONE |
-                     UART_CONFIG_WLEN_8));
-
-
-            ROM_UARTEnable(UART0_BASE);
             break;
 #endif
-        }
+#if UART_1_EN
+        case UART_1:
+            ROM_SysCtlPeripheralEnable(UART_1_PORT);
+            ROM_GPIOPinConfigure(UART_1_RX_PIN);
+            ROM_GPIOPinConfigure(UART_1_TX_PIN);
+            ROM_GPIOPinTypeUART(GPIO_PORTB_BASE, GPIO_PIN_0 | GPIO_PIN_1);
+            break;
+#endif
+    }
+    ROM_UARTDisable(ulBase);
+    ROM_UARTConfigSetExpClk(ulBase,UART_CLK, baudrate,
+            (UART_CONFIG_PAR_NONE | UART_CONFIG_STOP_ONE | UART_CONFIG_WLEN_8));
+    ROM_UARTEnable(ulBase);
+
     return 0;
 }
 
 void uart_tx_begin(uart_t uart)
 {
     uart_write(uart, '\0');
-    UART0_IM_R |= UART_IM_TXIM;
+    switch(uart){
+#if UART_0_EN
+        case UART_0:
+            UART_0_IM |= UART_IM_TXIM;
+            break;
+#endif
+#if UART_1_EN
+        case UART_1:
+            UART_1_IM |= UART_IM_TXIM;
+            break;
+#endif
+    }
 }
 
 int uart_write(uart_t uart, char data)
 {
-    int ret=ROM_UARTCharPutNonBlocking(UART0_BASE, data);
+    int ret=0;
+    switch(uart){
+#if UART_0_EN
+        case UART_0:
+            ret=ROM_UARTCharPutNonBlocking(UART_0_DEV, data);
+            break;
+#endif
+#if UART_1_EN
+        case UART_1:
+            ret=ROM_UARTCharPutNonBlocking(UART_1_DEV, data);
+            break;
+#endif
+    }
     return ret;
 }
 
 int uart_read_blocking(uart_t uart, char *data)
 {
-    *data = (char)ROM_UARTCharGet(UART0_BASE);
+    switch(uart){
+#if UART_0_EN
+        case UART_0:
+            *data = (char)ROM_UARTCharGet(UART_0_DEV);
+            break;
+#endif
+#if UART_1_EN
+        case UART_1:
+            *data = (char)ROM_UARTCharGet(UART_1_DEV);
+            break;
+#endif
+    }
     return 1;
 }
 
 int uart_write_blocking(uart_t uart, char data)
 {
-    ROM_UARTCharPut(UART0_BASE, data);
+    switch(uart){
+#if UART_0_EN
+        case UART_0:
+            ROM_UARTCharPut(UART_0_DEV, data);
+            break;
+#endif
+#if UART_1_EN
+        case UART_1:
+            ROM_UARTCharPut(UART_1_DEV, data);
+            break;
+#endif
+    }
     return 1;
 }
 
 void uart_poweron(uart_t uart)
 {
-    ROM_UARTEnable(UART0_BASE);
+    switch(uart){
+#if UART_0_EN
+        case UART_0:
+            ROM_UARTEnable(UART_0_DEV);
+            break;
+#endif
+#if UART_1_EN
+        case UART_1:
+            ROM_UARTEnable(UART_1_DEV);
+            break;
+#endif
+    }
 }
 
 void uart_poweroff(uart_t uart)
 {
-    ROM_UARTDisable(UART0_BASE);
+    switch(uart){
+#if UART_0_EN
+        case UART_0:
+            ROM_UARTDisable(UART_0_DEV);
+            break;
+#endif
+#if UART_1_EN
+        case UART_1:
+            ROM_UARTDisable(UART_0_DEV);
+            break;
+#endif
+    }
 }
 
 /**
  * The UART interrupt handler.
  */
-void isr_uart0(void)
+#if UART_0_EN
+void UART_0_ISR(void)
+{
+    irq_handler(UART_0, UART_0_DEV, UART_0_IM);
+}
+#endif
+
+#if UART_1_EN
+void UART_1_ISR(void)
+{
+    irq_handler(UART_1, UART_1_DEV, UART_1_IM);
+}
+#endif
+
+
+static inline void irq_handler(uart_t uartnum, unsigned long ulBase, unsigned long ulRxInt)
 {
     unsigned long ulStatus;
 
-    ulStatus = ROM_UARTIntStatus(UART0_BASE, true);
-    ROM_UARTIntClear(UART0_BASE, ulStatus);
+    ulStatus = ROM_UARTIntStatus(ulBase, true);
+    ROM_UARTIntClear(ulBase, ulStatus);
 
     /* Are we interrupted due to TX done */
     if(ulStatus & UART_INT_TX)
     {
-        if (config[UART_0].tx_cb(config[UART_0].arg) == 0){
-            UART0_IM_R &= ~UART_IM_TXIM;
+        if (config[uartnum].tx_cb(config[uartnum].arg) == 0){
+            ulRxInt &= ~UART_IM_TXIM;
         }
     }
 
     /* Are we interrupted due to a recieved character */
     if(ulStatus & (UART_INT_RX | UART_INT_RT))
     {
-        while(ROM_UARTCharsAvail(UART0_BASE))
+        while(ROM_UARTCharsAvail(ulBase))
         {
             char cChar;
             long lChar;
-            lChar = ROM_UARTCharGetNonBlocking(UART0_BASE);
+            lChar = ROM_UARTCharGetNonBlocking(ulBase);
             cChar = (unsigned char)(lChar & 0xFF);
-            config[UART_0].rx_cb(config[UART_0].arg, cChar);
+            config[uartnum].rx_cb(config[uartnum].arg, cChar);
         }
     }
     if (sched_context_switch_request) {
         thread_yield();
     }
 }
-#endif /*UART_0_EN*/
+#endif /*UART_NUMOF*/
 /** @} */


### PR DESCRIPTION
There's still ways to improve it. I guess I'll have a try later (eg. count down instead of up, that could save div).
Passes all xtimer tests (except shift_change, that does not compile)
